### PR TITLE
hwdb: Add quirk for Logitech MX Keys for Mac

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -1438,6 +1438,11 @@ evdev:input:b0003v046DpC309*
  KEYBOARD_KEY_c01b6=images                              # My Pictures (F11)
  KEYBOARD_KEY_c01b7=audio                               # My Music (F12)
 
+# Logitech MX Keys for Mac
+evdev:input:b0003v046Dp4092*
+ KEYBOARD_KEY_70035=102nd
+ KEYBOARD_KEY_70064=grave
+
 ###########################################################
 # Maxdata
 ###########################################################


### PR DESCRIPTION
The KEY_102ND and KEY_GRAVE keys are switched on the Logitech MX Keys for Mac, so switch them back

### Device info from `evtest`
```
Input driver version is 1.0.1
Input device ID: bus 0x3 vendor 0x46d product 0x4092 version 0x111
Input device name: "Logitech MX Keys Mac"
```

### Before this change

#### `evtest` output from pressing the "<" key
```
Event: time 1732141340.248080, type 4 (EV_MSC), code 4 (MSC_SCAN), value 70035
Event: time 1732141340.248080, type 1 (EV_KEY), code 41 (KEY_GRAVE), value 1
Event: time 1732141340.248080, -------------- SYN_REPORT ------------
Event: time 1732141340.330034, type 4 (EV_MSC), code 4 (MSC_SCAN), value 70035
Event: time 1732141340.330034, type 1 (EV_KEY), code 41 (KEY_GRAVE), value 0
Event: time 1732141340.330034, -------------- SYN_REPORT ------------
```

#### `evtest` output from pressing the "^" key
```
Event: time 1732141438.341698, type 4 (EV_MSC), code 4 (MSC_SCAN), value 70064
Event: time 1732141438.341698, type 1 (EV_KEY), code 86 (KEY_102ND), value 1
Event: time 1732141438.341698, -------------- SYN_REPORT ------------
Event: time 1732141438.421697, type 4 (EV_MSC), code 4 (MSC_SCAN), value 70064
Event: time 1732141438.421697, type 1 (EV_KEY), code 86 (KEY_102ND), value 0
Event: time 1732141438.421697, -------------- SYN_REPORT ------------
```

### After this change

#### `evtest` output from pressing the "<" key
```
Event: time 1732141567.769213, type 4 (EV_MSC), code 4 (MSC_SCAN), value 70035
Event: time 1732141567.769213, type 1 (EV_KEY), code 86 (KEY_102ND), value 1
Event: time 1732141567.769213, -------------- SYN_REPORT ------------
Event: time 1732141567.849245, type 4 (EV_MSC), code 4 (MSC_SCAN), value 70035
Event: time 1732141567.849245, type 1 (EV_KEY), code 86 (KEY_102ND), value 0
Event: time 1732141567.849245, -------------- SYN_REPORT ------------
```

#### `evtest` output from pressing the "^" key
```
Event: time 1732141591.217135, type 4 (EV_MSC), code 4 (MSC_SCAN), value 70064
Event: time 1732141591.217135, type 1 (EV_KEY), code 41 (KEY_GRAVE), value 1
Event: time 1732141591.217135, -------------- SYN_REPORT ------------
Event: time 1732141591.277127, type 4 (EV_MSC), code 4 (MSC_SCAN), value 70064
Event: time 1732141591.277127, type 1 (EV_KEY), code 41 (KEY_GRAVE), value 0
Event: time 1732141591.277127, -------------- SYN_REPORT ------------
```

Vendor product page: https://www.logitech.com/en-us/products/keyboards/mx-keys-mac-wireless-keyboard.920-009552.html

This is my first time contributing here, I hope I did everything correctly, please let me know if I missed anything.